### PR TITLE
added name and version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "create-nw-react-app",
+  "version": "1.0.8",
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "name": "create-nw-react-app",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
without those fields npm refuses to install from the git repo. reason why you'd want to do that: npm listed version is outdated (1.0.4 atm)