### PR TITLE
Update package.json in nw-react-scripts

### DIFF
--- a/packages/nw-react-scripts/package.json
+++ b/packages/nw-react-scripts/package.json
@@ -61,7 +61,7 @@
     "jest-resolve": "^27.4.2",
     "jest-watch-typeahead": "^1.0.0",
     "mini-css-extract-plugin": "^2.4.5",
-    "nw-builder": "^3.8.6",
+    "nw-builder": "^4.2.3",
     "postcss": "^8.4.4",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-loader": "^6.2.1",


### PR DESCRIPTION
nw-builder 3.8.6 has lost dependency(nw-install), so the version should be the latest 4.2.3